### PR TITLE
Bump actions/checkout and actions/cache to latest majors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
       contents: write
     container: bioconductor/bioconductor_docker:devel
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Query dependencies
         run: |
@@ -16,7 +16,7 @@ jobs:
 
       - name: Cache R packages
         if: runner.os != 'Windows'
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: /usr/local/lib/R/site-library
           key: ${{ runner.os }}-r-1-${{ hashFiles('.github/depends.Rds') }}


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` v4 → v7 and `actions/cache` v4 → v6 in `.github/workflows/build.yml`.
- Fixes the "Node.js 20 is deprecated" annotation on CI runs — both actions were previously being silently forced onto Node 24 by GitHub since their targeted Node 20 is going away on hosted runners; the new majors target Node 24 natively.

## Test plan
- [x] CI passes on this branch
