### PR TITLE
Add Compare Signatures vignette to pkgdown site, fix FunOmS load_all call

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -15,6 +15,8 @@ navbar:
       menu:
       - text: "Structure of OmicSignature & OmicSignatureCollection"
         href: articles/ObjectStructure.html
+      - text: "Compare Signatures"
+        href: articles/CompareSignatures.html
       - text: "---- OmicSignature ----"
       - text: "Create an OmicSignature"
         href: articles/CreateOmS.html

--- a/vignettes/CompareSignatures.Rmd
+++ b/vignettes/CompareSignatures.Rmd
@@ -29,8 +29,7 @@ the first factor level and the second factor level against the second factor
 level.
 
 ```{r}
-#library(OmicSignature)
-devtools::load_all()
+library(OmicSignature)
 
 data(compare_signatures_example)
 signature_list <- compare_signatures_example

--- a/vignettes/CreateOmS.Rmd
+++ b/vignettes/CreateOmS.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 ```
 
 ```{r message=FALSE, warning=FALSE}
-devtools::load_all(".")
+library(OmicSignature)
 library(dplyr)
 ```
 

--- a/vignettes/CreateOmSC.Rmd
+++ b/vignettes/CreateOmSC.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 ```
 
 ```{r message=FALSE, warning=FALSE}
-devtools::load_all(".")
+library(OmicSignature)
 library(dplyr)
 ```
 <font color = "#000000">

--- a/vignettes/FunOmS.Rmd
+++ b/vignettes/FunOmS.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 ```
 
 ```{r message=FALSE, warning=FALSE}
-devtools::load_all(".")
+library(OmicSignature)
 ```
 <font color = "#000000">
 

--- a/vignettes/FunOmSC.Rmd
+++ b/vignettes/FunOmSC.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 ```
 
 ```{r message=FALSE, warning=FALSE}
-devtools::load_all(".")
+library(OmicSignature)
 library(dplyr)
 ```
 <font color = "#000000">

--- a/vignettes/SampleType.Rmd
+++ b/vignettes/SampleType.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(echo = TRUE)
 <font color = "#000000">
 
 ```{r}
-devtools::load_all(".")
+library(OmicSignature)
 ```
 
 We use BRENDA tissue ontology to indicate the tissue or cell-line of a signature. BRENDA tissue ontology version: **10/2021**. The OBO file was downloaded at https://www.brenda-enzymes.org/ontology.php. \


### PR DESCRIPTION
## Summary
- Adds a "Compare Signatures" entry to the Articles dropdown in `pkgdown/_pkgdown.yml`, linking to the `CompareSignatures` vignette (added when `compare_omic_signatures()` and `signature_similarity_heatmap()` were merged in #46) so it now shows up on the gh-pages site.
- Fixes `vignettes/FunOmS.Rmd` (rendered as "Functionalities, imports and exports"): its first chunk called `devtools::load_all(".")`, a dev-only convenience; replaced with `library(OmicSignature)` to match the other vignettes and work correctly when the vignette is built from an installed package.

## Test plan
- [x] Rebuilt the pkgdown site locally (`pkgdown::build_site(".")`) and confirmed "Compare Signatures" appears in the Articles dropdown and links to the correct page
- [x] Confirmed `FunOmS.Rmd` now renders `library(OmicSignature)` instead of `load_all`
- [ ] CI passes
