### PR TITLE
Switch pkgdown theme to cosmo and shrink heading sizes

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -2,7 +2,7 @@ destination: docs
 
 template:
   bootstrap: 5
-  bootswatch: spacelab
+  bootswatch: cosmo
 
 url: https://montilab.github.io/OmicSignature/
 

--- a/pkgdown/extra.scss
+++ b/pkgdown/extra.scss
@@ -1,0 +1,19 @@
+// Shrink heading sizes for a more compact, professional look. Bootstrap's
+// default h1 (~2.5rem) reads as oversized for API/vignette documentation;
+// these sizes keep headings clearly distinguishable in hierarchy without
+// dominating the page.
+h1 {
+  font-size: 1.85rem;
+}
+
+h2 {
+  font-size: 1.45rem;
+}
+
+h3 {
+  font-size: 1.2rem;
+}
+
+h4 {
+  font-size: 1.05rem;
+}


### PR DESCRIPTION
## Summary
- Switches the pkgdown site's bootswatch theme from `spacelab` to `cosmo` for a cleaner, more professional look.
- Adds `pkgdown/extra.scss` to shrink `h1`-`h4` heading sizes (h1: 1.85rem, h2: 1.45rem, h3: 1.2rem, h4: 1.05rem), since Bootstrap's default heading scale reads as oversized for documentation regardless of bootswatch theme.

## Test plan
- [x] Compared `cosmo`, `litera`, `yeti`, and `flatly` locally before choosing `cosmo`
- [x] Rebuilt the full pkgdown site locally and confirmed the custom heading CSS compiles into the bundled stylesheet and renders as expected
