### PR TITLE
Change overlap counts to an integer matrix with a size row/column

### DIFF
--- a/R/compare_omic_signatures.R
+++ b/R/compare_omic_signatures.R
@@ -99,8 +99,13 @@
 #'   `method = "overlap"`, in which case `comparisons` directly contains
 #'   `jaccard`, `pvalue`, and `counts` (no `level1_vs_level1` nesting, and
 #'   `label_order` is `NULL`). Otherwise, for `method = "overlap"` each
-#'   element contains `jaccard`, `pvalue`, and `counts` matrices. `counts`
-#'   entries are formatted as `"ov | n1 | n2"`. For `method = "ks_rank"`,
+#'   element contains `jaccard`, `pvalue`, and `counts` matrices. `counts` is
+#'   an integer matrix with one extra final `"size"` row and column beyond
+#'   `jaccard`/`pvalue`'s dimensions: entry `[i, j]` is the overlap size
+#'   between signature `i` and signature `j`, the extra `"size"` column
+#'   reports each row signature's own retained feature-set size, the extra
+#'   `"size"` row reports each column signature's, and the corner entry is
+#'   `NA`. For `method = "ks_rank"`,
 #'   `method = "ks_score"`, `method = "ks"`, and
 #'   `method = "gsea"` each element contains `score` and `pvalue` matrices;
 #'   columns for `sig_list2` signatures without a difexp table, or that are
@@ -323,10 +328,10 @@ compare_omic_signatures <- function(
 
   jaccard <- pvalue <- matrix(NA_real_, length(set_list1), length(set_list2),
                               dimnames = list(names(set_list1), names(set_list2)))
-  counts <- matrix(NA_character_, length(set_list1), length(set_list2),
-                   dimnames = list(names(set_list1), names(set_list2)))
+  overlap <- matrix(NA_integer_, length(set_list1), length(set_list2),
+                    dimnames = list(names(set_list1), names(set_list2)))
 
-  ## Fill pairwise overlap, enrichment p-value, and count summary matrices.
+  ## Fill pairwise overlap, enrichment p-value, and overlap-size matrices.
   for (i in seq_along(set_list1)) {
     for (j in seq_along(set_list2)) {
       if (compare_self && j < i) next
@@ -334,7 +339,7 @@ compare_omic_signatures <- function(
       y <- intersect(set_list2[[j]], background)
       jaccard[i, j] <- .cos_jaccard(x, y)
       pvalue[i, j] <- .cos_fisher_overlap(x, y, background, alternative)
-      counts[i, j] <- paste(length(intersect(x, y)), length(x), length(y), sep = " | ")
+      overlap[i, j] <- length(intersect(x, y))
     }
   }
 
@@ -342,9 +347,19 @@ compare_omic_signatures <- function(
   if (compare_self) {
     jaccard <- .cos_fill_symmetric(jaccard, diag_value = 1)
     pvalue <- .cos_fill_symmetric(pvalue, diag_value = 0)
-    counts <- .cos_fill_symmetric(counts, diag_value = diag(counts))
+    overlap <- .cos_fill_symmetric(overlap, diag_value = diag(overlap))
   }
   pvalue <- .cos_adjust_matrix(pvalue, adjust, p_adjust_method, compare_self)
+
+  ## counts appends each signature's own (background-constrained) retained
+  ## feature-set size as an extra "size" row/column, so overlap counts can be
+  ## read alongside the set sizes they're drawn from without a separate call.
+  ## The corner entry (row size vs column size) isn't a meaningful overlap, so
+  ## it's left NA.
+  sizes1 <- vapply(set_list1, function(s) length(intersect(s, background)), integer(1))
+  sizes2 <- vapply(set_list2, function(s) length(intersect(s, background)), integer(1))
+  counts <- rbind(cbind(overlap, size = sizes1), size = c(sizes2, NA_integer_))
+  dimnames(counts) <- list(c(names(set_list1), "size"), c(names(set_list2), "size"))
 
   list(jaccard = jaccard, pvalue = pvalue, counts = counts)
 }

--- a/man/compare_omic_signatures.Rd
+++ b/man/compare_omic_signatures.Rd
@@ -145,8 +145,13 @@ signature in both `sig_list1` and `sig_list2` is uni-directional and
 `method = "overlap"`, in which case `comparisons` directly contains
 `jaccard`, `pvalue`, and `counts` (no `level1_vs_level1` nesting, and
 `label_order` is `NULL`). Otherwise, for `method = "overlap"` each
-element contains `jaccard`, `pvalue`, and `counts` matrices. `counts`
-entries are formatted as `"ov | n1 | n2"`. For `method = "ks_rank"`,
+element contains `jaccard`, `pvalue`, and `counts` matrices. `counts` is
+an integer matrix with one extra final `"size"` row and column beyond
+`jaccard`/`pvalue`'s dimensions: entry `[i, j]` is the overlap size
+between signature `i` and signature `j`, the extra `"size"` column
+reports each row signature's own retained feature-set size, the extra
+`"size"` row reports each column signature's, and the corner entry is
+`NA`. For `method = "ks_rank"`,
 `method = "ks_score"`, `method = "ks"`, and
 `method = "gsea"` each element contains `score` and `pvalue` matrices;
 columns for `sig_list2` signatures without a difexp table, or that are

--- a/tests/testthat/test-compare-omic-signatures.R
+++ b/tests/testthat/test-compare-omic-signatures.R
@@ -17,7 +17,16 @@ test_that("overlap comparison returns symmetric Jaccard and count matrices", {
   expect_equal(unname(diag(positive$jaccard)), c(1, 1))
   expect_equal(positive$jaccard["sig_a", "sig_b"], 1 / 3)
   expect_equal(positive$jaccard["sig_b", "sig_a"], 1 / 3)
-  expect_equal(positive$counts["sig_a", "sig_b"], "2 | 4 | 4")
+
+  ## counts is an integer matrix with an extra "size" row/column: the
+  ## overlap count in the core block, and each signature's own retained
+  ## feature-set size in the size row/column, with an NA corner.
+  expect_equal(dim(positive$counts), c(3L, 3L))
+  expect_equal(dimnames(positive$counts), list(c("sig_a", "sig_b", "size"), c("sig_a", "sig_b", "size")))
+  expect_equal(positive$counts["sig_a", "sig_b"], 2L)
+  expect_equal(positive$counts["sig_a", "size"], 4L)
+  expect_equal(positive$counts["size", "sig_b"], 4L)
+  expect_true(is.na(positive$counts["size", "size"]))
 })
 
 test_that("overlap comparison supports comparing two signature lists", {
@@ -410,7 +419,9 @@ test_that("overlap comparison of all uni-directional signatures drops the level 
   expect_named(res$comparisons, c("jaccard", "pvalue", "counts"))
   expect_null(res$label_order)
   expect_equal(res$comparisons$jaccard["uni_a", "uni_b"], 3 / 7)
-  expect_equal(res$comparisons$counts["uni_a", "uni_b"], "3 | 5 | 5")
+  expect_equal(res$comparisons$counts["uni_a", "uni_b"], 3L)
+  expect_equal(res$comparisons$counts["uni_a", "size"], 5L)
+  expect_equal(res$comparisons$counts["size", "uni_b"], 5L)
 })
 
 test_that("overlap comparison compares a uni-directional signature against both levels of a bi-directional one", {

--- a/vignettes/CompareSignatures.Rmd
+++ b/vignettes/CompareSignatures.Rmd
@@ -55,8 +55,11 @@ The overlap method returns three matrices for each compared factor level:
 
 * `jaccard`: Jaccard similarity between retained feature sets.
 * `pvalue`: Fisher exact test p-values for overlap enrichment.
-* `counts`: overlap size, first signature size, and second signature size,
-  formatted as `overlap | n1 | n2`.
+* `counts`: an integer matrix with an extra final `size` row and column
+  beyond `jaccard`/`pvalue`'s dimensions. Entry `[i, j]` is the overlap size
+  between signature `i` and signature `j`; the extra `size` column reports
+  each row signature's own retained feature-set size, the extra `size` row
+  reports each column signature's, and the corner entry is `NA`.
 
 ## Compare two lists of signatures
 


### PR DESCRIPTION
## Summary

`compare_omic_signatures(method = "overlap")`'s `counts` matrix changed from a character matrix of `"ov | n1 | n2"` strings to an integer matrix with an extra final `"size"` row and column:

```
             sig_a sig_b size
sig_a            4     2    4
sig_b            2     4    4
size             4     4   NA
```

- Core `[i, j]` entries: overlap size between signature `i` and signature `j`
- Extra `size` column: each row signature's own retained feature-set size
- Extra `size` row: each column signature's own size
- Corner entry: `NA` (not a meaningful value)

This applies uniformly wherever `.cos_compare_overlap()` is used, including the flat (no-level-nesting) output when every compared signature is uni-directional.

The change is contained to `compare_omic_signatures.R` — confirmed `signature_similarity_heatmap()` never reads `counts`.

## Test plan
- [x] Full `testthat` suite passes (127/127), including updated assertions for the new matrix shape/type
- [x] Full `R CMD check` passes (0 errors, 0 warnings, only the pre-existing `.github` NOTE), including re-building vignette outputs
- [x] Manually verified the new structure for self-comparison, cross-list comparison, and the all-uni-directional flat-output case
