### PR TITLE
Share a single legend in mode = "separate" heatmaps

### DIFF
--- a/R/signature_similarity_heatmap.R
+++ b/R/signature_similarity_heatmap.R
@@ -10,9 +10,11 @@
 #' Asymmetric KS and GSEA comparisons can show score or `-log10(p-value)`
 #' matrices. For these comparisons, `mode = "combined"` draws split cells: the
 #' top-right triangle shows `level2_vs_level2` and the bottom-left triangle
-#' shows `level1_vs_level1`. `mode = "separate"`
-#' draws one full heatmap per level, and `mode = "split"` is invalid. Legends
-#' for level-specific displays use abbreviated labels such as `"lev1_vs_lev1"`.
+#' shows `level1_vs_level1`. `mode = "separate"` draws one full heatmap per
+#' level, each panel titled with an abbreviated label such as
+#' `"lev1_vs_lev1"`; since both panels use the same color scale, they share a
+#' single combined legend rather than showing two identical ones.
+#' `mode = "split"` is invalid for rank-based comparisons.
 #'
 #' @param comparison Output from `compare_omic_signatures()`.
 #' @param measure One of `"jaccard"`, `"score"`, or `"pvalue"`.
@@ -203,10 +205,19 @@ signature_similarity_heatmap <- function(
   custom_heatmap_legends <- list()
 
   if (mode == "separate") {
-    ## Draw one heatmap per comparison level.
+    ## Draw one heatmap per comparison level. Both use the same color scale
+    ## (col_fun), so when there are two levels, share a single legend instead
+    ## of showing an identical one twice.
+    single_legend <- !is.null(sim$negative)
+
     positive_mat <- mask_redundant_triangle(sim$positive)
-    positive_args <- .ssh_set_legend_title(common_args, legend_names[1])
+    positive_args <- common_args
     positive_args$column_title <- legend_names[1]
+    if (single_legend) {
+      positive_args$show_heatmap_legend <- FALSE
+    } else {
+      positive_args <- .ssh_set_legend_title(positive_args, legend_names[1])
+    }
     positive_ht <- do.call(
       ComplexHeatmap::Heatmap,
       c(
@@ -216,12 +227,13 @@ signature_similarity_heatmap <- function(
       )
     )
     ht <- positive_ht
-    if (!is.null(sim$negative)) {
+    if (single_legend) {
       negative_mat <- mask_redundant_triangle(sim$negative)
-      negative_args <- .ssh_set_legend_title(common_args, legend_names[2])
+      negative_args <- common_args
       if (annotation_side == "column") negative_args$top_annotation <- NULL
       if (annotation_side == "row") negative_args$left_annotation <- NULL
       negative_args$column_title <- legend_names[2]
+      negative_args$show_heatmap_legend <- FALSE
       negative_ht <- do.call(
         ComplexHeatmap::Heatmap,
         c(
@@ -231,6 +243,9 @@ signature_similarity_heatmap <- function(
         )
       )
       ht <- positive_ht + negative_ht
+      custom_heatmap_legends <- list(.ssh_color_legend(
+        unlist(sim, use.names = FALSE), col_fun, .ssh_measure_legend_title(measure)
+      ))
     }
   } else if (mode == "split") {
     if (!is_self_similarity) {
@@ -534,8 +549,12 @@ signature_similarity_heatmap <- function(
 .ssh_color_legend <- function(values, col_fun, title) {
   ## Create a ComplexHeatmap color legend for custom-drawn cells.
   at <- .ssh_legend_at(values)
-  mapped_colors <- try(col_fun(at), silent = TRUE)
-  if (inherits(mapped_colors, "try-error") || length(mapped_colors) != length(at)) {
+  ## A continuous legend needs at least two distinct break points; when every
+  ## displayed value ties, ComplexHeatmap::Legend(at = <single value>, ...)
+  ## errors internally. Fall back to a single-swatch discrete legend instead.
+  needs_discrete_legend <- length(at) < 2
+  mapped_colors <- if (needs_discrete_legend) NULL else try(col_fun(at), silent = TRUE)
+  if (needs_discrete_legend || inherits(mapped_colors, "try-error") || length(mapped_colors) != length(at)) {
     mapped_colors <- vapply(at, col_fun, character(1))
     return(ComplexHeatmap::Legend(
       labels = at,

--- a/man/signature_similarity_heatmap.Rd
+++ b/man/signature_similarity_heatmap.Rd
@@ -68,9 +68,11 @@ similarity or p-value-based similarity on a `-log10(p-value)` scale.
 Asymmetric KS and GSEA comparisons can show score or `-log10(p-value)`
 matrices. For these comparisons, `mode = "combined"` draws split cells: the
 top-right triangle shows `level2_vs_level2` and the bottom-left triangle
-shows `level1_vs_level1`. `mode = "separate"`
-draws one full heatmap per level, and `mode = "split"` is invalid. Legends
-for level-specific displays use abbreviated labels such as `"lev1_vs_lev1"`.
+shows `level1_vs_level1`. `mode = "separate"` draws one full heatmap per
+level, each panel titled with an abbreviated label such as
+`"lev1_vs_lev1"`; since both panels use the same color scale, they share a
+single combined legend rather than showing two identical ones.
+`mode = "split"` is invalid for rank-based comparisons.
 }
 \examples{
 data(compare_signatures_example)

--- a/tests/testthat/test-signature-similarity-heatmap.R
+++ b/tests/testthat/test-signature-similarity-heatmap.R
@@ -289,6 +289,82 @@ test_that("combined heatmap adds abbreviated legends for distinct color scales",
   expect_equal(.legend_titles(legends), c("lev2_vs_lev2", "lev1_vs_lev1"))
 })
 
+test_that("separate mode shares a single legend for overlap comparisons", {
+  skip_if_not_installed("ComplexHeatmap")
+  skip_if_not_installed("circlize")
+
+  jaccard_mat <- matrix(
+    c(1, 0.5, 0.5, 1),
+    nrow = 2,
+    dimnames = list(c("a", "b"), c("a", "b"))
+  )
+  comparison <- list(
+    method = "overlap",
+    comparisons = list(
+      level1_vs_level1 = list(jaccard = jaccard_mat),
+      level2_vs_level2 = list(jaccard = jaccard_mat / 2)
+    )
+  )
+
+  separate_ht <- signature_similarity_heatmap(comparison, measure = "jaccard", mode = "separate", draw = FALSE)
+  legends <- attr(separate_ht, "heatmap_legend_list")
+
+  expect_length(legends, 1)
+  expect_equal(.legend_titles(legends), "jaccard")
+  expect_false(separate_ht@ht_list[[1]]@heatmap_param$show_heatmap_legend)
+  expect_false(separate_ht@ht_list[[2]]@heatmap_param$show_heatmap_legend)
+  ## Column titles still distinguish the two panels.
+  expect_equal(separate_ht@ht_list[[1]]@column_title, "lev1_vs_lev1")
+  expect_equal(separate_ht@ht_list[[2]]@column_title, "lev2_vs_lev2")
+})
+
+test_that("separate mode shares a single legend for rank-based comparisons", {
+  skip_if_not_installed("ComplexHeatmap")
+  skip_if_not_installed("circlize")
+
+  score_level1 <- matrix(
+    c(1, 4, 2, 3),
+    nrow = 2,
+    dimnames = list(c("a", "b"), c("a", "b"))
+  )
+  score_level2 <- matrix(
+    c(-1, -4, -2, -3),
+    nrow = 2,
+    dimnames = list(c("a", "b"), c("a", "b"))
+  )
+  comparison <- list(
+    method = "ks",
+    comparisons = list(
+      level1_vs_level1 = list(score = score_level1, pvalue = abs(score_level1) / 10),
+      level2_vs_level2 = list(score = score_level2, pvalue = abs(score_level2) / 10)
+    )
+  )
+
+  separate_ht <- signature_similarity_heatmap(comparison, measure = "score", mode = "separate", draw = FALSE)
+  legends <- attr(separate_ht, "heatmap_legend_list")
+
+  expect_length(legends, 1)
+  expect_equal(.legend_titles(legends), "score")
+  expect_false(separate_ht@ht_list[[1]]@heatmap_param$show_heatmap_legend)
+  expect_false(separate_ht@ht_list[[2]]@heatmap_param$show_heatmap_legend)
+})
+
+test_that("color legend falls back to a discrete swatch when every value ties", {
+  skip_if_not_installed("ComplexHeatmap")
+  skip_if_not_installed("circlize")
+
+  col_fun <- circlize::colorRamp2(c(0, 1), c("white", "#b2182b"))
+
+  ## Regression test: ComplexHeatmap::Legend(at = <single value>, col_fun = ...)
+  ## errors internally, since a continuous legend needs >= 2 distinct breaks.
+  expect_no_error(
+    legend <- OmicSignature:::.ssh_color_legend(c(5, 5, 5), col_fun, "test")
+  )
+  ## The discrete-swatch fallback (labels + legend_gp) returns ComplexHeatmap's
+  ## "Legends" class, distinct from the continuous at/col_fun "Legend" class.
+  expect_s4_class(legend, "Legends")
+})
+
 test_that("combined triangle cell_fun renders NA halves without calling their color function", {
   skip_if_not_installed("ComplexHeatmap")
   skip_if_not_installed("circlize")


### PR DESCRIPTION
## Summary

- `mode = "separate"` heatmaps (both overlap/jaccard and rank-based KS/GSEA) now show a **single shared color legend** instead of two identical ones, since both panels (`level1_vs_level1`/`level2_vs_level2`) always use the same color scale. Each panel keeps its own distinguishing title (e.g. `lev1_vs_lev1`).
- **Bug fix found along the way**: `ComplexHeatmap::Legend(at = <single value>, col_fun = ...)` errors internally when every displayed value ties (e.g. p-values all underflowing to the same `-log10` value) — a continuous legend needs at least two distinct break points. This is a **pre-existing bug** that already affected `mode = "combined"` independently of this change, but would have newly affected the `mode = "separate"` change too. `.ssh_color_legend()` now falls back to a single-swatch discrete legend in that degenerate case.

## Test plan
- [x] Full `testthat` suite passes (139/139), including new tests for the single-legend behavior (overlap and rank-based) and the degenerate-value legend fallback
- [x] Full `R CMD check` passes (0 errors, 0 warnings, only the pre-existing `.github` NOTE), including re-building vignette outputs (which exercise the heatmap chunks)
- [x] Manually verified the previously-crashing `mode = "combined"`/`mode = "separate"` + `measure = "pvalue"` degenerate scenario now works
