### PR TITLE
Simplify overlap counts matrix and let the Articles dropdown expand

### DIFF
--- a/R/compare_omic_signatures.R
+++ b/R/compare_omic_signatures.R
@@ -100,12 +100,10 @@
 #'   `jaccard`, `pvalue`, and `counts` (no `level1_vs_level1` nesting, and
 #'   `label_order` is `NULL`). Otherwise, for `method = "overlap"` each
 #'   element contains `jaccard`, `pvalue`, and `counts` matrices. `counts` is
-#'   an integer matrix with one extra final `"size"` row and column beyond
-#'   `jaccard`/`pvalue`'s dimensions: entry `[i, j]` is the overlap size
-#'   between signature `i` and signature `j`, the extra `"size"` column
-#'   reports each row signature's own retained feature-set size, the extra
-#'   `"size"` row reports each column signature's, and the corner entry is
-#'   `NA`. For `method = "ks_rank"`,
+#'   an integer matrix with the same dimensions as `jaccard`/`pvalue`: entry
+#'   `[i, j]` is the overlap size between signature `i` and signature `j`.
+#'   For self-comparisons, the diagonal is therefore each signature's own
+#'   retained feature-set size. For `method = "ks_rank"`,
 #'   `method = "ks_score"`, `method = "ks"`, and
 #'   `method = "gsea"` each element contains `score` and `pvalue` matrices;
 #'   columns for `sig_list2` signatures without a difexp table, or that are
@@ -351,17 +349,7 @@ compare_omic_signatures <- function(
   }
   pvalue <- .cos_adjust_matrix(pvalue, adjust, p_adjust_method, compare_self)
 
-  ## counts appends each signature's own (background-constrained) retained
-  ## feature-set size as an extra "size" row/column, so overlap counts can be
-  ## read alongside the set sizes they're drawn from without a separate call.
-  ## The corner entry (row size vs column size) isn't a meaningful overlap, so
-  ## it's left NA.
-  sizes1 <- vapply(set_list1, function(s) length(intersect(s, background)), integer(1))
-  sizes2 <- vapply(set_list2, function(s) length(intersect(s, background)), integer(1))
-  counts <- rbind(cbind(overlap, size = sizes1), size = c(sizes2, NA_integer_))
-  dimnames(counts) <- list(c(names(set_list1), "size"), c(names(set_list2), "size"))
-
-  list(jaccard = jaccard, pvalue = pvalue, counts = counts)
+  list(jaccard = jaccard, pvalue = pvalue, counts = overlap)
 }
 
 .cos_drop_small_sets <- function(set_list1, set_list2, min_features, compare_self) {

--- a/man/compare_omic_signatures.Rd
+++ b/man/compare_omic_signatures.Rd
@@ -146,12 +146,10 @@ signature in both `sig_list1` and `sig_list2` is uni-directional and
 `jaccard`, `pvalue`, and `counts` (no `level1_vs_level1` nesting, and
 `label_order` is `NULL`). Otherwise, for `method = "overlap"` each
 element contains `jaccard`, `pvalue`, and `counts` matrices. `counts` is
-an integer matrix with one extra final `"size"` row and column beyond
-`jaccard`/`pvalue`'s dimensions: entry `[i, j]` is the overlap size
-between signature `i` and signature `j`, the extra `"size"` column
-reports each row signature's own retained feature-set size, the extra
-`"size"` row reports each column signature's, and the corner entry is
-`NA`. For `method = "ks_rank"`,
+an integer matrix with the same dimensions as `jaccard`/`pvalue`: entry
+`[i, j]` is the overlap size between signature `i` and signature `j`.
+For self-comparisons, the diagonal is therefore each signature's own
+retained feature-set size. For `method = "ks_rank"`,
 `method = "ks_score"`, `method = "ks"`, and
 `method = "gsea"` each element contains `score` and `pvalue` matrices;
 columns for `sig_list2` signatures without a difexp table, or that are

--- a/pkgdown/extra.scss
+++ b/pkgdown/extra.scss
@@ -17,3 +17,12 @@ h3 {
 h4 {
   font-size: 1.05rem;
 }
+
+// pkgdown's default .dropdown-menu caps every navbar dropdown at a fixed
+// 280px, forcing a scrollbar on the Articles menu even though its content
+// fits comfortably on screen. Scale the cap to the viewport instead: it
+// stays scrollable if the menu grows past most of the screen's height, but
+// doesn't truncate it prematurely at the current length.
+.dropdown-menu {
+  max-height: 85vh;
+}

--- a/tests/testthat/test-compare-omic-signatures.R
+++ b/tests/testthat/test-compare-omic-signatures.R
@@ -18,15 +18,12 @@ test_that("overlap comparison returns symmetric Jaccard and count matrices", {
   expect_equal(positive$jaccard["sig_a", "sig_b"], 1 / 3)
   expect_equal(positive$jaccard["sig_b", "sig_a"], 1 / 3)
 
-  ## counts is an integer matrix with an extra "size" row/column: the
-  ## overlap count in the core block, and each signature's own retained
-  ## feature-set size in the size row/column, with an NA corner.
-  expect_equal(dim(positive$counts), c(3L, 3L))
-  expect_equal(dimnames(positive$counts), list(c("sig_a", "sig_b", "size"), c("sig_a", "sig_b", "size")))
+  ## counts is an integer matrix with the same dimensions as jaccard/pvalue;
+  ## for self-comparisons the diagonal is each signature's own size.
+  expect_equal(dim(positive$counts), c(2L, 2L))
+  expect_equal(dimnames(positive$counts), list(c("sig_a", "sig_b"), c("sig_a", "sig_b")))
   expect_equal(positive$counts["sig_a", "sig_b"], 2L)
-  expect_equal(positive$counts["sig_a", "size"], 4L)
-  expect_equal(positive$counts["size", "sig_b"], 4L)
-  expect_true(is.na(positive$counts["size", "size"]))
+  expect_equal(unname(diag(positive$counts)), c(4L, 4L))
 })
 
 test_that("overlap comparison supports comparing two signature lists", {
@@ -420,8 +417,7 @@ test_that("overlap comparison of all uni-directional signatures drops the level 
   expect_null(res$label_order)
   expect_equal(res$comparisons$jaccard["uni_a", "uni_b"], 3 / 7)
   expect_equal(res$comparisons$counts["uni_a", "uni_b"], 3L)
-  expect_equal(res$comparisons$counts["uni_a", "size"], 5L)
-  expect_equal(res$comparisons$counts["size", "uni_b"], 5L)
+  expect_equal(unname(diag(res$comparisons$counts)), c(5L, 5L))
 })
 
 test_that("overlap comparison compares a uni-directional signature against both levels of a bi-directional one", {

--- a/vignettes/CompareSignatures.Rmd
+++ b/vignettes/CompareSignatures.Rmd
@@ -44,10 +44,14 @@ overlap_res <- compare_omic_signatures(
 )
 ## show the label order
 overlap_res$label_order
+
 ## list the comparisons being performed
 names(overlap_res$comparisons)
+
 ## show the comparison results for level 1 (jaccard and counts)
 overlap_res$comparisons$level1_vs_level1$jaccard
+
+## in the counts matrix, you can see the signature sizes in the diagonal
 overlap_res$comparisons$level1_vs_level1$counts
 ```
 
@@ -55,11 +59,10 @@ The overlap method returns three matrices for each compared factor level:
 
 * `jaccard`: Jaccard similarity between retained feature sets.
 * `pvalue`: Fisher exact test p-values for overlap enrichment.
-* `counts`: an integer matrix with an extra final `size` row and column
-  beyond `jaccard`/`pvalue`'s dimensions. Entry `[i, j]` is the overlap size
-  between signature `i` and signature `j`; the extra `size` column reports
-  each row signature's own retained feature-set size, the extra `size` row
-  reports each column signature's, and the corner entry is `NA`.
+* `counts`: an integer matrix with the same dimensions as `jaccard`/`pvalue`.
+  Entry `[i, j]` is the overlap size between signature `i` and signature `j`;
+  for self-comparisons, the diagonal is therefore each signature's own
+  retained feature-set size.
 
 ## Compare two lists of signatures
 
@@ -112,7 +115,10 @@ paired_res <- compare_omic_signatures(
     signature_c = c("resistant", "sensitive")
   )
 )
+## level1 vs. level1
 paired_res$comparisons$level1_vs_level1$jaccard
+
+## level2 vs. level2
 paired_res$comparisons$level2_vs_level2$jaccard
 ```
 
@@ -158,8 +164,11 @@ toy_ks_score <- compare_omic_signatures(
 )
 
 round(toy_ks_score$comparisons$level1_vs_level1$score, 3)
+
 signif(toy_ks_score$comparisons$level1_vs_level1$pvalue, 3)
+
 round(toy_ks_score$comparisons$level2_vs_level2$score, 3)
+
 signif(toy_ks_score$comparisons$level2_vs_level2$pvalue, 3)
 ```
 
@@ -193,7 +202,11 @@ signature_similarity_heatmap(
   row_names_gp = grid::gpar(fontsize = 9),
   column_names_rot = 45
 )
+```
 
+With `mode="combined"`, a single triangular matrix is shown, with each entry divided
+into two triangles displaying the level2 (top-right) and level1 (bottom-left) similarity.
+```{r}
 signature_similarity_heatmap(
   overlap_res,
   measure = "jaccard",


### PR DESCRIPTION
## Summary

Two independent changes:

1. **Simplify overlap `counts` matrix** — `compare_omic_signatures(method = "overlap")`'s `counts` drops the extra `size` row/column added in a previous PR. It's now a plain integer matrix with the same dimensions as `jaccard`/`pvalue`; for self-comparisons the diagonal already reports each signature's own retained feature-set size (overlap of a signature with itself), making the extra row/column redundant.
2. **Let the Articles navbar dropdown expand** — pkgdown's bundled CSS caps every navbar dropdown at a fixed `max-height: 280px` regardless of content, which forced a scrollbar on the Articles menu even though its content fits on typical screens. `pkgdown/extra.scss` now overrides this to a viewport-relative `85vh`, so the menu displays in full without scrolling at its current length, while the inherited `overflow-y: auto` still activates the scrollbar if the menu grows past most of the viewport in the future.

Also includes some manual touch-ups to `vignettes/CompareSignatures.Rmd`.

## Test plan
- [x] Full `testthat` suite passes (136/136), including updated assertions for the simplified `counts` shape
- [x] Full `R CMD check` passes (0 errors, 0 warnings, only the pre-existing `.github` NOTE), including re-building vignette outputs
- [x] Rebuilt the full pkgdown site locally and confirmed the `.dropdown-menu` CSS cascade resolves to `max-height: 85vh` with `overflow-y: auto` preserved
