### PR TITLE
Make combined-mode heatmap triangle placement consistent across measures

### DIFF
--- a/R/signature_similarity_heatmap.R
+++ b/R/signature_similarity_heatmap.R
@@ -8,13 +8,13 @@
 #' `compare_omic_signatures()`. Overlap comparisons can show Jaccard
 #' similarity or p-value-based similarity on a `-log10(p-value)` scale.
 #' Asymmetric KS and GSEA comparisons can show score or `-log10(p-value)`
-#' matrices. For these comparisons, `mode = "combined"` draws split cells: the
-#' top-right triangle shows `level2_vs_level2` and the bottom-left triangle
-#' shows `level1_vs_level1`. `mode = "separate"` draws one full heatmap per
-#' level, each panel titled with an abbreviated label such as
-#' `"lev1_vs_lev1"`; since both panels use the same color scale, they share a
-#' single combined legend rather than showing two identical ones.
-#' `mode = "split"` is invalid for rank-based comparisons.
+#' matrices. For both, `mode = "combined"` draws split cells: the top-right
+#' triangle shows `level2_vs_level2` and the bottom-left triangle shows
+#' `level1_vs_level1`. `mode = "separate"` draws one full heatmap per level,
+#' each panel titled with an abbreviated label such as `"lev1_vs_lev1"`;
+#' since both panels use the same color scale, they share a single combined
+#' legend rather than showing two identical ones. `mode = "split"` is
+#' invalid for rank-based comparisons.
 #'
 #' @param comparison Output from `compare_omic_signatures()`.
 #' @param measure One of `"jaccard"`, `"score"`, or `"pvalue"`.
@@ -288,16 +288,11 @@ signature_similarity_heatmap <- function(
             rect_gp = grid::gpar(type = "none"),
             cell_fun = function(j, i, x, y, width, height, fill) {
               if (!is_visible_triangle_cell(i, j)) return(NULL)
-              top_right_value <- if (is_rank_based) {
-                sim$negative[i, j]
-              } else {
-                sim$positive[i, j]
-              }
-              bottom_left_value <- if (is_rank_based) {
-                sim$positive[i, j]
-              } else {
-                sim$negative[i, j]
-              }
+              ## Consistent across overlap and rank-based comparisons: level1
+              ## (sim$positive) always bottom-left, level2 (sim$negative)
+              ## always top-right.
+              top_right_value <- sim$negative[i, j]
+              bottom_left_value <- sim$positive[i, j]
               top_right_x <- grid::unit.c(x - width / 2, x + width / 2, x + width / 2)
               top_right_y <- grid::unit.c(y + height / 2, y + height / 2, y - height / 2)
               bottom_left_x <- grid::unit.c(x - width / 2, x - width / 2, x + width / 2)

--- a/man/signature_similarity_heatmap.Rd
+++ b/man/signature_similarity_heatmap.Rd
@@ -66,13 +66,13 @@ Plot one or more ComplexHeatmap heatmaps from the object returned by
 `compare_omic_signatures()`. Overlap comparisons can show Jaccard
 similarity or p-value-based similarity on a `-log10(p-value)` scale.
 Asymmetric KS and GSEA comparisons can show score or `-log10(p-value)`
-matrices. For these comparisons, `mode = "combined"` draws split cells: the
-top-right triangle shows `level2_vs_level2` and the bottom-left triangle
-shows `level1_vs_level1`. `mode = "separate"` draws one full heatmap per
-level, each panel titled with an abbreviated label such as
-`"lev1_vs_lev1"`; since both panels use the same color scale, they share a
-single combined legend rather than showing two identical ones.
-`mode = "split"` is invalid for rank-based comparisons.
+matrices. For both, `mode = "combined"` draws split cells: the top-right
+triangle shows `level2_vs_level2` and the bottom-left triangle shows
+`level1_vs_level1`. `mode = "separate"` draws one full heatmap per level,
+each panel titled with an abbreviated label such as `"lev1_vs_lev1"`;
+since both panels use the same color scale, they share a single combined
+legend rather than showing two identical ones. `mode = "split"` is
+invalid for rank-based comparisons.
 }
 \examples{
 data(compare_signatures_example)

--- a/tests/testthat/test-signature-similarity-heatmap.R
+++ b/tests/testthat/test-signature-similarity-heatmap.R
@@ -138,6 +138,49 @@ test_that("combined heatmap supports two-list overlap comparisons", {
   )
 })
 
+test_that("combined triangle placement is consistent between overlap and rank-based comparisons", {
+  skip_if_not_installed("ComplexHeatmap")
+  skip_if_not_installed("circlize")
+
+  ## level1 and level2 use clearly distinguishable values so the triangle
+  ## receiving each one can be identified from which color function fires.
+  level1_mat <- matrix(0.9, 2, 2, dimnames = list(c("a", "b"), c("a", "b")))
+  level2_mat <- matrix(0.1, 2, 2, dimnames = list(c("a", "b"), c("a", "b")))
+  comparison <- list(
+    method = "overlap",
+    comparisons = list(
+      level1_vs_level1 = list(jaccard = level1_mat),
+      level2_vs_level2 = list(jaccard = level2_mat)
+    )
+  )
+
+  seen <- character()
+  pos_col_fun <- function(x) { seen <<- c(seen, paste0("level1:", x)); "#000000" }
+  neg_col_fun <- function(x) { seen <<- c(seen, paste0("level2:", x)); "#111111" }
+
+  combined_ht <- signature_similarity_heatmap(
+    comparison,
+    measure = "jaccard",
+    mode = "combined",
+    draw = FALSE,
+    pos_col_fun = pos_col_fun,
+    neg_col_fun = neg_col_fun
+  )
+
+  seen <- character()
+  grid::grid.newpage()
+  ## Cell (row 1, col 2): top-right is filled first in source order and must
+  ## be level2 (0.1, via neg_col_fun); bottom-left is filled second and must
+  ## be level1 (0.9, via pos_col_fun) - matching rank-based.
+  combined_ht@matrix_param$cell_fun(
+    2, 1,
+    grid::unit(0.5, "npc"), grid::unit(0.5, "npc"),
+    grid::unit(1, "npc"), grid::unit(1, "npc"),
+    NA
+  )
+  expect_equal(seen, c("level2:0.1", "level1:0.9"))
+})
+
 test_that("rank-based heatmaps support combined and separate modes only", {
   skip_if_not_installed("ComplexHeatmap")
   skip_if_not_installed("circlize")


### PR DESCRIPTION
## Summary

`signature_similarity_heatmap(mode = "combined")` placed `level1`/`level2` in opposite triangles depending on comparison type:

- Rank-based (KS/GSEA): `level1_vs_level1` bottom-left, `level2_vs_level2` top-right
- Overlap (`measure = "jaccard"`/`"pvalue"`): `level1_vs_level1` top-right, `level2_vs_level2` bottom-left — the reverse

This also meant `pos_col_fun`/`neg_col_fun` were applied to the wrong triangle's values for overlap comparisons whenever the two color functions differed (each is documented as coloring a specific level's triangle).

Fixed by dropping the `is_rank_based` branch in the triangle `cell_fun` — both cases now consistently place `level2` (`sim$negative`) top-right (colored by `neg_col_fun`) and `level1` (`sim$positive`) bottom-left (colored by `pos_col_fun`).

## Test plan
- [x] Full `testthat` suite passes (137/137), including a new regression test that traces triangle placement and color-function pairing for an overlap comparison
- [x] Full `R CMD check` passes (0 errors, 0 warnings, only the pre-existing `.github` NOTE), including re-building vignette outputs
- [x] Empirically verified (traced actual values through the rendering path, not just read the code) that overlap combined-mode heatmaps now match the rank-based convention
