### PR TITLE
Fix group_label consistency issues (#57, #58, #59, #60)

### DIFF
--- a/R/OmicSignature.R
+++ b/R/OmicSignature.R
@@ -157,7 +157,25 @@ OmicSignature <-
         if (missing(value)) {
           private$.metadata
         } else {
-          private$.metadata <- private$checkMetadata(value, v = print_message)
+          new_metadata <- private$checkMetadata(value, v = print_message)
+          if (!identical(new_metadata$direction_type, private$.metadata$direction_type)) {
+            ## direction_type governs what's required/meaningful in signature
+            ## and difexp (e.g. group_label); re-validate both against the
+            ## new type instead of letting metadata and data go structurally
+            ## out of sync silently.
+            private$.signature <- private$checkSignature(
+              private$.signature, signatureType = new_metadata$direction_type, v = print_message
+            )
+            if (!is.null(private$.difexp)) {
+              private$.difexp <- private$checkDifexp(
+                private$.difexp, signatureType = new_metadata$direction_type, v = print_message
+              )
+            }
+            if (new_metadata$direction_type == "uni-directional") {
+              private$checkNoStaleGroupLabel(private$.signature, private$.difexp)
+            }
+          }
+          private$.metadata <- new_metadata
         }
       },
       #' @field signature a dataframe contains probe_id, feature_name, score (optional) and group_label (optional)
@@ -199,6 +217,26 @@ OmicSignature <-
       verbose = function(v, ...) {
         if (v) cat(...)
       },
+      checkNoStaleGroupLabel = function(signature, difexp) {
+        ## checkSignature()/checkDifexp() only enforce required columns for
+        ## the new direction_type; a multi-level group_label column left
+        ## over from a prior bi-directional/categorical direction_type is
+        ## structurally harmless under uni-directional's laxer requirements,
+        ## but would be silently ignored by anything that trusts
+        ## metadata$direction_type alone (e.g. compare_omic_signatures()).
+        has_stale <- function(df) {
+          !is.null(df) && "group_label" %in% colnames(df) && nlevels(df$group_label) > 1
+        }
+        if (has_stale(signature) || has_stale(difexp)) {
+          stop(
+            "Cannot change direction_type to 'uni-directional': signature and/or difexp ",
+            "still has a multi-level group_label column, which would be silently ignored ",
+            "downstream. Remove group_label from signature/difexp first, or construct a ",
+            "new OmicSignature object instead."
+          )
+        }
+        invisible(TRUE)
+      },
       checkDifexp = function(difexp, signatureType = NULL, v = FALSE) {
         if (is.null(difexp)) stop("Please use build-in function $removeDifexp.")
         if (is(difexp, "OmicSignature")) difexp <- difexp$difexp
@@ -209,7 +247,7 @@ OmicSignature <-
         if (nrow(difexp) == 0) stop("difexp is empty. ")
 
         ## check column names:
-        difexpColRequired <- c("probe_id", "feature_name", "score", "group_label")
+        difexpColRequired <- c("probe_id", "feature_name", "score")
         if (signatureType != "uni-directional") {
           difexpColRequired <- c(difexpColRequired, "group_label")
         }

--- a/R/readwriteJson.R
+++ b/R/readwriteJson.R
@@ -15,9 +15,15 @@ writeJson <- function(OmicObj, file) {
   writeSignature <- OmicObj$signature
   # add "sig_" prefix to column names to avoid confusion with columns in difexp
   names(writeSignature) <- paste0("sig_", names(writeSignature))
+  sig_group_label_levels <- if ("group_label" %in% colnames(OmicObj$signature)) {
+    levels(OmicObj$signature$group_label)
+  } else {
+    NULL
+  }
 
   #### difexp ####
   writeDifexp <- NULL
+  difexp_group_label_levels <- NULL
   if (!is.null(OmicObj$difexp)) {
     # add "difexp_" prefix to column names to avoid confusion with other entries
     difexp_formatted <- OmicObj$difexp
@@ -26,12 +32,23 @@ writeJson <- function(OmicObj, file) {
       list("difexp_colnames" = colnames(difexp_formatted)),
       difexp_formatted
     )
+    if ("group_label" %in% colnames(OmicObj$difexp)) {
+      difexp_group_label_levels <- levels(OmicObj$difexp$group_label)
+    }
   }
 
   #### write json ####
   writeJsonObj <- jsonlite::toJSON(c(
     OmicObj$metadata,
-    "metadata_length" = length(OmicObj$metadata),
+    list(
+      "metadata_length" = length(OmicObj$metadata),
+      ## Written since this field was added, so readJson() can look metadata
+      ## fields up by name instead of assuming they're the first
+      ## metadata_length top-level keys in file order.
+      "metadata_fields" = names(OmicObj$metadata)
+    ),
+    if (!is.null(sig_group_label_levels)) list(sig_group_label_levels = sig_group_label_levels),
+    if (!is.null(difexp_group_label_levels)) list(difexp_group_label_levels = difexp_group_label_levels),
     writeSignature,
     writeDifexp
   ), na = NULL, pretty = TRUE)
@@ -45,7 +62,7 @@ writeJson <- function(OmicObj, file) {
 #' @description To avoid confusion, in the json text file, assume the column
 #' names in signature dataframe and difexp dataframe have prefix "sig_"
 #' and "difexp". This corresponds to writeJson() function.
-#' updated 04/2024
+#' updated 08/2025
 #'
 #' @param filename json file name to read in
 #' @return OmicSignature object
@@ -54,7 +71,15 @@ readJson <- function(filename) {
   readJson <- jsonlite::fromJSON(txt = filename)
 
   #### metadata ####
-  readMetadata <- readJson[c(1:readJson$metadata_length)]
+  ## Prefer looking metadata fields up by name via metadata_fields (written
+  ## by writeJson() since this was added); fall back to the legacy
+  ## assumption that metadata fields are the first metadata_length top-level
+  ## keys, for files written before metadata_fields existed.
+  if (!is.null(readJson$metadata_fields)) {
+    readMetadata <- readJson[readJson$metadata_fields]
+  } else {
+    readMetadata <- readJson[c(1:readJson$metadata_length)]
+  }
 
   #### difexp ####
   readDifexp <- NULL
@@ -62,7 +87,16 @@ readJson <- function(filename) {
     readDifexp <- data.frame(dplyr::bind_rows(readJson[c(readJson$difexp_colnames)]))
     colnames(readDifexp) <- gsub("difexp_", "", colnames(readDifexp))
     if ("group_label" %in% colnames(readDifexp)) {
-      readDifexp$group_label <- as.factor(as.character(readDifexp$group_label))
+      ## difexp_group_label_levels is absent for files written before this
+      ## was added; factor(x, levels = NULL) is *not* the same as omitting
+      ## levels (it produces an all-NA factor), so levels must only be
+      ## passed when actually present, falling back to auto-detected
+      ## (sorted unique) levels otherwise, matching the previous behavior.
+      readDifexp$group_label <- if (!is.null(readJson$difexp_group_label_levels)) {
+        factor(as.character(readDifexp$group_label), levels = readJson$difexp_group_label_levels)
+      } else {
+        as.factor(as.character(readDifexp$group_label))
+      }
     }
   } else {
     cat(paste("Notice: ", filename, "does not have difexp data. \n"))
@@ -74,7 +108,11 @@ readJson <- function(filename) {
     readSignature$score <- as.numeric(as.character(readJson$sig_score))
   }
   if (!is.null(readJson$sig_group_label)) {
-    readSignature$group_label <- as.factor(as.character(readJson$sig_group_label))
+    readSignature$group_label <- if (!is.null(readJson$sig_group_label_levels)) {
+      factor(as.character(readJson$sig_group_label), levels = readJson$sig_group_label_levels)
+    } else {
+      as.factor(as.character(readJson$sig_group_label))
+    }
   }
 
   #### Obj ####

--- a/R/standardizeSigDF.R
+++ b/R/standardizeSigDF.R
@@ -26,8 +26,17 @@ standardizeSigDF <- function(sigdf) {
       dplyr::arrange(desc(abs(score)))
   }
   if ("group_label" %in% colnames(sigdf)) {
+    ## Preserve the caller's factor level order (e.g. control-first) instead
+    ## of resetting to alphabetical order; compare_omic_signatures() pairs
+    ## signatures by level position, so a silently reordered level1/level2
+    ## can compare mismatched conditions across signatures. Levels with no
+    ## observed rows are still dropped (e.g. a signature pre-filtered to one
+    ## group upstream), matching the prior as.factor()-based behavior.
+    observed <- as.character(sigdf$group_label)
+    declared_order <- if (is.factor(sigdf$group_label)) levels(sigdf$group_label) else unique(observed)
+    group_label_levels <- intersect(declared_order, unique(observed))
     sigdf <- sigdf %>%
-      dplyr::mutate(group_label = as.factor(as.character(group_label)))
+      dplyr::mutate(group_label = factor(as.character(group_label), levels = group_label_levels))
   }
   return(sigdf)
 }

--- a/man/readJson.Rd
+++ b/man/readJson.Rd
@@ -16,5 +16,5 @@ OmicSignature object
 To avoid confusion, in the json text file, assume the column
 names in signature dataframe and difexp dataframe have prefix "sig_"
 and "difexp". This corresponds to writeJson() function.
-updated 04/2024
+updated 08/2025
 }

--- a/tests/testthat/test-OmicSignature.R
+++ b/tests/testthat/test-OmicSignature.R
@@ -18,3 +18,67 @@ test_that("signature and difexp active bindings accept updates after constructio
   sig$signature <- relabeled
   expect_equal(levels(sig$signature$group_label), c("down", "up"))
 })
+
+test_that("checkDifexp() does not require group_label for uni-directional signatures", {
+  metadata <- list(
+    signature_name = "u", phenotype = "test",
+    organism = predefined_organisms[1], direction_type = "uni-directional",
+    assay_type = predefined_assaytypes[1]
+  )
+  signature <- data.frame(feature_name = c("A", "B"), score = c(1, 2))
+  difexp <- data.frame(
+    probe_id = 1:2, feature_name = c("A", "B"), score = c(1, 2), p_value = c(0.01, 0.02)
+  )
+
+  ## Regression test: checkDifexp()'s required-columns list included
+  ## group_label unconditionally, contradicting checkSignature()'s handling
+  ## of the signature table and forcing a meaningless placeholder column.
+  expect_no_error(
+    capture.output(
+      sig <- OmicSignature$new(metadata = metadata, signature = signature, difexp = difexp)
+    )
+  )
+  expect_false("group_label" %in% colnames(sig$difexp))
+})
+
+test_that("metadata<- re-validates signature/difexp when direction_type changes", {
+  bi_metadata <- list(
+    signature_name = "bi", phenotype = "test",
+    organism = predefined_organisms[1], direction_type = "bi-directional",
+    assay_type = predefined_assaytypes[1]
+  )
+  bi_signature <- data.frame(
+    probe_id = 1:4, feature_name = c("a", "b", "c", "d"),
+    group_label = factor(c("up", "up", "down", "down"), levels = c("up", "down"))
+  )
+  capture.output(bi <- OmicSignature$new(metadata = bi_metadata, signature = bi_signature))
+
+  ## Regression test: demoting direction_type to uni-directional used to
+  ## succeed silently even though signature still had a multi-level
+  ## group_label column, which compare_omic_signatures() would then ignore
+  ## entirely based on metadata$direction_type alone.
+  expect_error(
+    bi$metadata <- modifyList(bi_metadata, list(direction_type = "uni-directional")),
+    "multi-level group_label"
+  )
+  expect_equal(bi$metadata$direction_type, "bi-directional")
+
+  uni_metadata <- list(
+    signature_name = "u", phenotype = "test",
+    organism = predefined_organisms[1], direction_type = "uni-directional",
+    assay_type = predefined_assaytypes[1]
+  )
+  uni_signature <- data.frame(feature_name = c("a", "b"), score = c(1, 2))
+  capture.output(uni <- OmicSignature$new(metadata = uni_metadata, signature = uni_signature))
+
+  ## Promoting to bi-directional without a group_label column should also
+  ## be rejected (re-validated via checkSignature()).
+  expect_error(
+    uni$metadata <- modifyList(uni_metadata, list(direction_type = "bi-directional")),
+    "group_label"
+  )
+
+  ## An unrelated metadata change (same direction_type) is unaffected.
+  capture.output(bi$metadata <- modifyList(bi_metadata, list(author = "someone")))
+  expect_equal(bi$metadata$author, "someone")
+})

--- a/tests/testthat/test-readwriteJson.R
+++ b/tests/testthat/test-readwriteJson.R
@@ -1,0 +1,97 @@
+test_that("writeJson()/readJson() round trip preserves group_label factor level order", {
+  ## Regression test: readJson() used to rebuild group_label via
+  ## as.factor(as.character(...)), losing whatever level order the original
+  ## object had, for both signature and difexp.
+  metadata <- list(
+    signature_name = "rt", phenotype = "test",
+    organism = predefined_organisms[1], direction_type = "bi-directional",
+    assay_type = predefined_assaytypes[1]
+  )
+  signature <- data.frame(
+    probe_id = 1:4, feature_name = c("a", "b", "c", "d"),
+    group_label = factor(c("ICG001", "ICG001", "DMSO", "DMSO"), levels = c("ICG001", "DMSO"))
+  )
+  difexp <- data.frame(
+    probe_id = 1:4, feature_name = c("a", "b", "c", "d"), score = c(2, 1, -1, -2),
+    p_value = c(0.01, 0.02, 0.03, 0.04),
+    group_label = factor(c("ICG001", "ICG001", "DMSO", "DMSO"), levels = c("ICG001", "DMSO"))
+  )
+  capture.output(obj <- OmicSignature$new(metadata = metadata, signature = signature, difexp = difexp))
+
+  tmpfile <- tempfile(fileext = ".json")
+  capture.output(writeJson(obj, tmpfile))
+  capture.output(obj2 <- readJson(tmpfile))
+
+  expect_equal(levels(obj2$signature$group_label), c("ICG001", "DMSO"))
+  expect_equal(levels(obj2$difexp$group_label), c("ICG001", "DMSO"))
+})
+
+test_that("writeJson()/readJson() round trip recovers metadata by name, not position", {
+  metadata <- list(
+    signature_name = "rt2", phenotype = "test",
+    organism = predefined_organisms[1], direction_type = "uni-directional",
+    assay_type = predefined_assaytypes[1], author = "someone"
+  )
+  signature <- data.frame(feature_name = c("a", "b"), score = c(1, 2))
+  capture.output(obj <- OmicSignature$new(metadata = metadata, signature = signature))
+
+  tmpfile <- tempfile(fileext = ".json")
+  capture.output(writeJson(obj, tmpfile))
+  capture.output(obj2 <- readJson(tmpfile))
+
+  expect_equal(obj2$metadata$signature_name, "rt2")
+  expect_equal(obj2$metadata$author, "someone")
+  expect_equal(obj2$metadata$direction_type, "uni-directional")
+})
+
+test_that("readJson() falls back to positional metadata lookup for files without metadata_fields", {
+  ## Simulates a file written before metadata_fields was added, to confirm
+  ## old files remain readable.
+  raw <- jsonlite::fromJSON(jsonlite::toJSON(list(
+    signature_name = "legacy", phenotype = "test",
+    organism = predefined_organisms[1], direction_type = "uni-directional",
+    assay_type = predefined_assaytypes[1],
+    metadata_length = 5,
+    sig_probe_id = c("p1", "p2"),
+    sig_feature_name = c("a", "b"),
+    sig_score = c(1, 2)
+  ), auto_unbox = TRUE))
+
+  tmpfile <- tempfile(fileext = ".json")
+  write(jsonlite::toJSON(raw, na = NULL, pretty = TRUE, auto_unbox = TRUE), tmpfile)
+
+  capture.output(obj <- readJson(tmpfile))
+  expect_equal(obj$metadata$signature_name, "legacy")
+})
+
+test_that("readJson() correctly reconstructs group_label for files without *_group_label_levels", {
+  ## Regression test: factor(x, levels = NULL) is *not* equivalent to
+  ## omitting levels (it produces an all-NA factor), so a naive fix that
+  ## always passes levels = readJson$sig_group_label_levels would silently
+  ## turn every group_label into NA for files written before that field
+  ## existed - exactly the files this fallback is supposed to support.
+  raw <- jsonlite::fromJSON(jsonlite::toJSON(list(
+    signature_name = "legacy_bi", phenotype = "test",
+    organism = predefined_organisms[1], direction_type = "bi-directional",
+    assay_type = predefined_assaytypes[1],
+    metadata_length = 5,
+    sig_probe_id = c("p1", "p2", "p3", "p4"),
+    sig_feature_name = c("a", "b", "c", "d"),
+    sig_score = c(2, 1, -1, -2),
+    sig_group_label = c("up", "up", "down", "down")
+  ), auto_unbox = TRUE))
+
+  tmpfile <- tempfile(fileext = ".json")
+  write(jsonlite::toJSON(raw, na = NULL, pretty = TRUE, auto_unbox = TRUE), tmpfile)
+
+  capture.output(obj <- readJson(tmpfile))
+  ## standardizeSigDF() sorts rows by descending |score|, so check group
+  ## membership rather than row order.
+  expect_false(anyNA(obj$signature$group_label))
+  expect_setequal(
+    obj$signature$feature_name[obj$signature$group_label == "up"], c("a", "b")
+  )
+  expect_setequal(
+    obj$signature$feature_name[obj$signature$group_label == "down"], c("c", "d")
+  )
+})

--- a/tests/testthat/test-standardizeSigDF.R
+++ b/tests/testthat/test-standardizeSigDF.R
@@ -1,0 +1,43 @@
+test_that("standardizeSigDF() preserves caller-specified group_label factor level order", {
+  ## Regression test: standardizeSigDF() used to rebuild group_label via
+  ## as.factor(as.character(...)), which silently reset the level order to
+  ## alphabetical regardless of how the caller constructed it.
+  df <- data.frame(
+    probe_id = 1:4, feature_name = c("a", "b", "c", "d"),
+    group_label = factor(c("ICG001", "ICG001", "DMSO", "DMSO"), levels = c("ICG001", "DMSO"))
+  )
+  result <- standardizeSigDF(df)
+  expect_equal(levels(result$group_label), c("ICG001", "DMSO"))
+})
+
+test_that("standardizeSigDF() still drops group_label levels with no observed rows", {
+  ## A signature pre-filtered to one group upstream shouldn't retain the
+  ## other, unobserved level, even though its order-preserving fix now keeps
+  ## the *order* of whatever levels remain.
+  df <- data.frame(
+    probe_id = 1:2, feature_name = c("a", "b"),
+    group_label = factor(c("ICG001", "ICG001"), levels = c("ICG001", "DMSO"))
+  )
+  result <- standardizeSigDF(df)
+  expect_equal(levels(result$group_label), "ICG001")
+})
+
+test_that("standardizeSigDF() preserves declared order even when a level is filtered out", {
+  df <- data.frame(
+    probe_id = 1:4, feature_name = c("a", "b", "c", "d"),
+    group_label = factor(c("DMSO", "DMSO", "ICG001", "ICG001"), levels = c("DMSO", "ICG001"))
+  )
+  filtered <- df[df$group_label == "ICG001", ]
+  result <- standardizeSigDF(filtered)
+  expect_equal(levels(result$group_label), "ICG001")
+})
+
+test_that("standardizeSigDF() falls back to first-appearance order for non-factor group_label", {
+  df <- data.frame(
+    probe_id = 1:4, feature_name = c("a", "b", "c", "d"),
+    group_label = c("ICG001", "ICG001", "DMSO", "DMSO"),
+    stringsAsFactors = FALSE
+  )
+  result <- standardizeSigDF(df)
+  expect_equal(levels(result$group_label), c("ICG001", "DMSO"))
+})


### PR DESCRIPTION
## Summary

Fixes #57, #58, #59, #60 — four related issues from the code review where declared state (factor level order, `direction_type`) could silently drift from actual structure.

- **#57** `standardizeSigDF()` rebuilt `group_label` via `as.factor(as.character(...))`, always resetting to alphabetical order regardless of how the caller constructed it. Now preserves the caller's declared order for whichever levels are still observed after filtering (levels with zero rows are still dropped, matching the prior behavior).
- **#58** `writeJson()`/`readJson()` lost `group_label` factor order on every round trip (same root cause as #57, different code path), and recovered metadata via positional indexing into the parsed JSON rather than by name. `writeJson()` now additionally records each table's declared `group_label` levels and an explicit `metadata_fields` list; `readJson()` uses these when present and falls back to the previous behavior for files written before this change, so existing archived `.json` files stay readable.
- **#59** `checkDifexp()` required a `group_label` column unconditionally (it was already in the base required-columns list *before* the `signatureType`-conditional branch meant to gate it), contradicting `checkSignature()`'s handling of the same concept for `signature`, and forcing a meaningless placeholder column onto uni-directional signatures with a `difexp` table.
- **#60** `metadata <-` never re-validated `signature`/`difexp` against a changed `direction_type`, letting an object end up with e.g. `metadata$direction_type == "uni-directional"` while `signature` still had a multi-level `group_label` column from when it was bi-directional — silently ignored by anything (like `compare_omic_signatures()`) that trusts `metadata$direction_type` alone. Now re-runs `checkSignature()`/`checkDifexp()` against the new type and rejects `direction_type` changes that would leave a stale multi-level `group_label` column.

**Caught and fixed a real regression along the way**: my first pass at #58's fallback for legacy JSON files used `factor(x, levels = readJson$sig_group_label_levels)`, but `factor(x, levels = NULL)` is *not* equivalent to omitting `levels` — it produces an all-`NA` factor instead of auto-detecting levels. This broke reading the bundled example JSON file (used in 3 vignettes) until caught by `R CMD check`'s vignette rebuilding step. Fixed by only passing `levels` when actually present.

## Test plan
- [x] Full `testthat` suite passes (156/156), including new dedicated test files for `standardizeSigDF()` and `readwriteJson.R`, and new tests for the `checkDifexp()`/`metadata<-` fixes
- [x] Full `R CMD check` passes (0 errors, 0 warnings, only the pre-existing `.github` NOTE), including re-building all vignette outputs (this is what caught the `levels = NULL` regression above)
- [x] Manually verified all four fixes and the legacy-file backward-compatibility path
